### PR TITLE
Fix quoting for ParentCommandLine

### DIFF
--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -895,7 +895,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = sysmon-splunk-app
 request.ui_dispatch_view = search
-search = `sysmon` `sysmon`  EventCode=1 Image="C:\\Windows\\system32\\rundll32.exe" CommandLine=*C:\\Users\\* ParentCommandLine=\"C:\\Program Files\\Internet Explorer\\Iexplore.exe\"
+search = `sysmon` `sysmon`  EventCode=1 Image="C:\\Windows\\system32\\rundll32.exe" CommandLine=*C:\\Users\\* ParentCommandLine="\"C:\\Program Files\\Internet Explorer\\iexplore.exe\""
 
 [IOC - Certutil Decode in Appdata]
 action.email.useNSSubject = 1


### PR DESCRIPTION
The quotes are also included in the field value. Should this be a TA fix, instead?